### PR TITLE
Pin blit thread to isolated CPU core to prevent flicker during animation

### DIFF
--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <fstream>
+#include <iostream>
+#include <pthread.h>
+#include <sched.h>
 #include <thread>
 
 #include "hardware/pio.h"
@@ -195,7 +199,29 @@ struct piomatter : piomatter_base {
         pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, false);
     }
 
+    static bool has_isol_cpu_3() {
+        std::string buf;
+        std::ifstream f("/sys/devices/system/cpu/isolated");
+        if (f) {
+            std::getline(f, buf);
+        }
+        return buf.find('3') != std::string::npos;
+    }
+
     void blit_thread() {
+        // Pin to isolated CPU 3 if available (set via isolcpus=3 in
+        // cmdline.txt) to avoid scheduler jitter during DMA transfers.
+        if (has_isol_cpu_3()) {
+            cpu_set_t cpuset;
+            CPU_ZERO(&cpuset);
+            CPU_SET(3, &cpuset);
+            pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
+        } else {
+            std::cerr
+                << "Suggestion: to improve display update, add\n\tisolcpus=3\n"
+                   "at the end of /boot/firmware/cmdline.txt and reboot.\n";
+        }
+
         int cur_buffer_idx = buffer_manager::no_buffer;
         int buffer_idx;
         int seq_idx = -1;

--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -199,27 +199,46 @@ struct piomatter : piomatter_base {
         pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, false);
     }
 
-    static bool has_isol_cpu_3() {
-        std::string buf;
+    // Return the first isolated CPU number from /sys/devices/system/cpu/isolated,
+    // or -1 if none are isolated. Handles single CPUs ("3"), comma-separated
+    // lists ("1,3") and ranges ("2-3"); the leading entry is used either way.
+    static int find_isolated_cpu() {
         std::ifstream f("/sys/devices/system/cpu/isolated");
-        if (f) {
-            std::getline(f, buf);
+        if (!f) {
+            return -1;
         }
-        return buf.find('3') != std::string::npos;
+        std::string buf;
+        std::getline(f, buf);
+        if (buf.empty()) {
+            return -1;
+        }
+        std::string first = buf.substr(0, buf.find_first_of(",-"));
+        try {
+            return std::stoi(first);
+        } catch (...) {
+            return -1;
+        }
     }
 
     void blit_thread() {
-        // Pin to isolated CPU 3 if available (set via isolcpus=3 in
+        // Pin to an isolated CPU if available (set via isolcpus=N in
         // cmdline.txt) to avoid scheduler jitter during DMA transfers.
-        if (has_isol_cpu_3()) {
+        int cpu = find_isolated_cpu();
+        if (cpu >= 0) {
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
-            CPU_SET(3, &cpuset);
+            CPU_SET(cpu, &cpuset);
             pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
         } else {
-            std::cerr
-                << "Suggestion: to improve display update, add\n\tisolcpus=3\n"
-                   "at the end of /boot/firmware/cmdline.txt and reboot.\n";
+            // Print once per process even when multiple piomatter instances
+            // are created.
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                std::cerr
+                    << "Suggestion: to improve display update, add\n\tisolcpus=3\n"
+                       "(or another core) at the end of /boot/firmware/cmdline.txt and reboot.\n";
+            }
         }
 
         int cur_buffer_idx = buffer_manager::no_buffer;


### PR DESCRIPTION
## Summary

- Inspired by [hzeller/rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix), which uses the same approach to prevent scheduler jitter from disrupting scan timing
- Check /sys/devices/system/cpu/isolated for CPU 3 and pin the blit thread to it via pthread_setaffinity_np
- Prints a suggestion to set isolcpus=3 if no isolated core is found
- Drastically reduces flickering during animations in larger panel chains

## Testing

Tested on Pi 5 with isolcpus=3. Eliminates visible flicker during animation that was caused by the blit thread being preempted mid-DMA-transfer.