### PR TITLE
Add hardware brightness property to PioMatter

### DIFF
--- a/examples/virtualdisplay.py
+++ b/examples/virtualdisplay.py
@@ -25,7 +25,6 @@ from subprocess import Popen
 
 import click
 import numpy as np
-from PIL import ImageEnhance
 from pyvirtualdisplay.smartdisplay import SmartDisplay
 
 import adafruit_blinka_raspberry_pi5_piomatter as piomatter
@@ -60,6 +59,7 @@ def main(scale, backend, use_xauth, extra_args, rfbport, brightness, width, heig
                                       n_temporal_planes=n_temporal_planes, rotation=rotation, serpentine=serpentine)
     framebuffer = np.zeros(shape=(geometry.height, geometry.width, 3), dtype=np.uint8)
     matrix = piomatter.PioMatter(colorspace=piomatter.Colorspace.RGB888Packed, pinout=pinout, framebuffer=framebuffer, geometry=geometry)
+    matrix.brightness = brightness
 
     with SmartDisplay(backend=backend, use_xauth=use_xauth, size=(round(width*scale),round(height*scale)), manage_global_env=False, **kwargs) as disp, Popen(command, env=disp.env()) as proc:
             while proc.poll() is None:
@@ -67,9 +67,6 @@ def main(scale, backend, use_xauth, extra_args, rfbport, brightness, width, heig
 
                 if img is None:
                     continue
-                if brightness != 1.0:
-                    darkener = ImageEnhance.Brightness(img)
-                    img = darkener.enhance(brightness)
                 img = img.resize((width, height))
                 framebuffer[:, :] = np.array(img)
                 matrix.show()

--- a/examples/xdisplay_mirror.py
+++ b/examples/xdisplay_mirror.py
@@ -20,7 +20,7 @@ This example command will mirror a 128x128 pixel square from the top left of the
 
 import click
 import numpy as np
-from PIL import Image, ImageEnhance, ImageGrab
+from PIL import Image, ImageGrab
 
 import adafruit_blinka_raspberry_pi5_piomatter as piomatter
 import adafruit_blinka_raspberry_pi5_piomatter.click as piomatter_click
@@ -57,6 +57,7 @@ def main(width, height, serpentine, rotation, pinout, n_planes,
     framebuffer = np.zeros(shape=(geometry.height, geometry.width, 3), dtype=np.uint8)
     matrix = piomatter.PioMatter(colorspace=piomatter.Colorspace.RGB888Packed, pinout=pinout, framebuffer=framebuffer,
                                  geometry=geometry)
+    matrix.brightness = brightness
 
     if mirror_region:
         mirror_region = tuple(int(_) for _ in mirror_region.split(','))
@@ -71,9 +72,6 @@ def main(width, height, serpentine, rotation, pinout, n_planes,
             img = img.crop((mirror_region[0], mirror_region[1],    # left,top
                             mirror_region[0] + mirror_region[2],   # right
                             mirror_region[1] + mirror_region[3]))  # bottom
-        if brightness != 1.0:
-            darkener = ImageEnhance.Brightness(img)
-            img = darkener.enhance(brightness)
         img = img.resize((width, height), RESAMPLE_MAP[resample_method])
 
         framebuffer[:, :] = np.array(img)

--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -96,10 +96,9 @@ struct piomatter : piomatter_base {
         auto converted = converter.convert(framebuffer);
         auto old_active_time = geometry.schedules.back().back().active_time;
         for (size_t i = 0; i < geometry.schedules.size(); i++) {
-            protomatter_render_rgb10<pinout>(bufseq[i], geometry,
-                                             geometry.schedules[i],
-                                             old_active_time, converted.data(),
-                                             brightness);
+            protomatter_render_rgb10<pinout>(
+                bufseq[i], geometry, geometry.schedules[i], old_active_time,
+                converted.data(), brightness);
             old_active_time = geometry.schedules[i].back().active_time;
         }
         manager.put_filled_buffer(buffer_idx);

--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -65,6 +65,7 @@ struct piomatter_base {
     virtual int show() = 0;
 
     double fps;
+    float brightness = 1.0f;
 };
 
 template <class pinout = adafruit_matrix_bonnet_pinout,
@@ -97,7 +98,8 @@ struct piomatter : piomatter_base {
         for (size_t i = 0; i < geometry.schedules.size(); i++) {
             protomatter_render_rgb10<pinout>(bufseq[i], geometry,
                                              geometry.schedules[i],
-                                             old_active_time, converted.data());
+                                             old_active_time, converted.data(),
+                                             brightness);
             old_active_time = geometry.schedules[i].back().active_time;
         }
         manager.put_filled_buffer(buffer_idx);

--- a/src/include/piomatter/render.h
+++ b/src/include/piomatter/render.h
@@ -133,7 +133,8 @@ template <typename pinout>
 void protomatter_render_rgb10(std::vector<uint32_t> &result,
                               const matrix_geometry &matrixmap,
                               const schedule &sched, uint32_t old_active_time,
-                              const uint32_t *pixels) {
+                              const uint32_t *pixels,
+                              float brightness = 1.0f) {
     result.clear();
 
     int data_count = 0;
@@ -154,7 +155,7 @@ void protomatter_render_rgb10(std::vector<uint32_t> &result,
         data_count = n;
     };
 
-    int32_t active_time = old_active_time;
+    int32_t active_time = old_active_time * brightness;
 
     auto do_data_clk_active = [&active_time, &data_count, &result](uint32_t d) {
         bool active = active_time > 0;
@@ -231,7 +232,7 @@ void protomatter_render_rgb10(std::vector<uint32_t> &result,
             do_data_delay(addr_bits | pinout::oe_inactive | pinout::lat_bit,
                           pinout::post_latch_delay);
 
-            active_time = schedule_ent.active_time;
+            active_time = schedule_ent.active_time * brightness;
 
             // with oe inactive, set address bits to illuminate THIS line
             if (addr != prev_addr) {

--- a/src/include/piomatter/render.h
+++ b/src/include/piomatter/render.h
@@ -133,8 +133,7 @@ template <typename pinout>
 void protomatter_render_rgb10(std::vector<uint32_t> &result,
                               const matrix_geometry &matrixmap,
                               const schedule &sched, uint32_t old_active_time,
-                              const uint32_t *pixels,
-                              float brightness = 1.0f) {
+                              const uint32_t *pixels, float brightness = 1.0f) {
     result.clear();
 
     int data_count = 0;

--- a/src/pymain.cpp
+++ b/src/pymain.cpp
@@ -28,7 +28,9 @@ struct PyPiomatter {
     }
     double fps() const { return matter->fps; }
     float get_brightness() const { return matter->brightness; }
-    void set_brightness(float b) { matter->brightness = std::max(0.f, std::min(1.f, b)); }
+    void set_brightness(float b) {
+        matter->brightness = std::max(0.f, std::min(1.f, b));
+    }
 };
 
 template <typename pinout, typename colorspace>
@@ -291,7 +293,8 @@ data is triple-buffered to prevent tearing.
         .def_property_readonly("fps", &PyPiomatter::fps, R"pbdoc(
 The approximate number of matrix refreshes per second.
 )pbdoc")
-        .def_property("brightness", &PyPiomatter::get_brightness, &PyPiomatter::set_brightness, R"pbdoc(
+        .def_property("brightness", &PyPiomatter::get_brightness,
+                      &PyPiomatter::set_brightness, R"pbdoc(
 The brightness of the matrix, from 0.0 (off) to 1.0 (full brightness).
 
 Controls the OE (output enable) duty cycle to adjust overall panel brightness.

--- a/src/pymain.cpp
+++ b/src/pymain.cpp
@@ -27,6 +27,8 @@ struct PyPiomatter {
         }
     }
     double fps() const { return matter->fps; }
+    float get_brightness() const { return matter->brightness; }
+    void set_brightness(float b) { matter->brightness = std::max(0.f, std::min(1.f, b)); }
 };
 
 template <typename pinout, typename colorspace>
@@ -288,5 +290,11 @@ data is triple-buffered to prevent tearing.
 )pbdoc")
         .def_property_readonly("fps", &PyPiomatter::fps, R"pbdoc(
 The approximate number of matrix refreshes per second.
+)pbdoc")
+        .def_property("brightness", &PyPiomatter::get_brightness, &PyPiomatter::set_brightness, R"pbdoc(
+The brightness of the matrix, from 0.0 (off) to 1.0 (full brightness).
+
+Controls the OE (output enable) duty cycle to adjust overall panel brightness.
+Default is 1.0.
 )pbdoc");
 }


### PR DESCRIPTION
## Summary
- Add `brightness` property (0.0–1.0) to `PioMatter` for hardware-level brightness control via OE duty cycle
- Update examples (`virtualdisplay.py`, `xdisplay_mirror.py`) to use hardware brightness instead of PIL `ImageEnhance`

Closes #81

## Test matrix

| Panel | Product | Brightness |
|-------|---------|------------|
| [64x64 2mm](https://www.adafruit.com/product/5362) | ADA 5362 | ✅ |
| [64x32 2.5mm](https://www.adafruit.com/product/5036) | ADA 5036 | ✅ |
| [64x32 4mm](https://www.adafruit.com/product/2278) | ADA 2278 | ✅ |
| [64x64 3mm](https://www.adafruit.com/product/4732) | ADA 4732 | ❌ Pre-existing panel compatibility issue |

🤖 Generated with [Claude Code](https://claude.com/claude-code)