### PR TITLE
Add stripe multiplexing for 64x64 outdoor panels

### DIFF
--- a/src/adafruit_blinka_raspberry_pi5_piomatter/pixelmappers.py
+++ b/src/adafruit_blinka_raspberry_pi5_piomatter/pixelmappers.py
@@ -28,3 +28,64 @@ def simple_multilane_mapper(width, height, n_addr_lines, n_lanes):
                 y = addr + lane * n_addr
                 m.append(x + width * y)
     return m
+
+
+def stripe_multiplex_mapper(width, height):
+    """A mapper for panels with stripe multiplexing (e.g. 64x64 outdoor panels)
+
+    Some panels interleave top/bottom row stripes across a double-width shift register.
+    This mapper handles panels that use 128-pixel shifts with 5 address lines, such as the
+    Adafruit 4732 (64x64 3mm pitch).
+
+    Returns ``(framebuffer_shape, geometry_kwargs)`` where ``framebuffer_shape`` is the
+    shape to use for the numpy framebuffer array and ``geometry_kwargs`` are the keyword
+    arguments to pass to ``Geometry``.
+
+    Usage::
+
+        from adafruit_blinka_raspberry_pi5_piomatter.pixelmappers import stripe_multiplex_mapper
+
+        fb_shape, geo_kwargs = stripe_multiplex_mapper(64, 64)
+        framebuffer = np.zeros(shape=fb_shape, dtype=np.uint8)
+        geometry = piomatter.Geometry(**geo_kwargs)
+
+        # Draw into framebuffer columns 0..width-1 as normal
+        framebuffer[:32, :32] = [255, 0, 0]  # top-left red
+    """
+
+    n_addr_lines = 5
+    n_addr = 1 << n_addr_lines
+    virt_w = width * 2
+    virt_h = height
+    pixels_across = virt_w * virt_h // (2 << n_addr_lines)
+    half_addr = n_addr // 2
+
+    m = []
+    for addr in range(n_addr):
+        for shift_x in range(pixels_across):
+            for lane in range(2):
+                eff_addr = addr % half_addr
+                matrix_y = eff_addr + lane * half_addr
+                if shift_x >= width:
+                    is_top = True
+                    vis_x = shift_x - width
+                else:
+                    is_top = False
+                    vis_x = shift_x
+                base = (matrix_y // half_addr) * (height // 2)
+                offset = matrix_y % half_addr
+                if is_top:
+                    vis_y = base + offset
+                else:
+                    vis_y = base + offset + half_addr
+                m.append(vis_x + virt_w * vis_y)
+
+    framebuffer_shape = (virt_h, virt_w, 3)
+    geometry_kwargs = {
+        "width": virt_w,
+        "height": virt_h,
+        "n_addr_lines": n_addr_lines,
+        "map": m,
+        "n_lanes": 2,
+    }
+    return framebuffer_shape, geometry_kwargs

--- a/src/include/piomatter/piomatter.h
+++ b/src/include/piomatter/piomatter.h
@@ -114,7 +114,7 @@ struct piomatter : piomatter_base {
             for (const auto p : pinout::PIN_RGB)
                 pin_deinit_one(p);
 
-            for (size_t i = 0; i < geometry.n_addr_lines; i++) {
+            for (size_t i = 0; i < std::size(pinout::PIN_ADDR); i++) {
                 pin_deinit_one(pinout::PIN_ADDR[i]);
             }
             pio_sm_unclaim(pio, sm);
@@ -179,7 +179,7 @@ struct piomatter : piomatter_base {
         for (const auto p : pinout::PIN_RGB)
             pin_init_one(p);
 
-        for (size_t i = 0; i < geometry.n_addr_lines; i++) {
+        for (size_t i = 0; i < std::size(pinout::PIN_ADDR); i++) {
             pin_init_one(pinout::PIN_ADDR[i]);
         }
     }


### PR DESCRIPTION
## Summary
- Add `stripe_multiplex_mapper` for 64x64 panels like [ADA 4732](https://www.adafruit.com/product/4732) (3mm pitch) that use a different internal pixel layout than standard panels like [ADA 5362](https://www.adafruit.com/product/5362) (2mm pitch)
- Always init all address pins so unused lines are driven to a known state

## Usage
```python
from adafruit_blinka_raspberry_pi5_piomatter.pixelmappers import stripe_multiplex_mapper

fb_shape, geo_kwargs = stripe_multiplex_mapper(64, 64)
framebuffer = np.zeros(shape=fb_shape, dtype=np.uint8)
geometry = piomatter.Geometry(**geo_kwargs)
```

## Tested on
- [64x64 3mm](https://www.adafruit.com/product/4732) (ADA 4732) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)